### PR TITLE
Legacy colors

### DIFF
--- a/.storybook/global.svelte
+++ b/.storybook/global.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-  import '../build/css/_variables.css'
+  import '../build/css/variables.css'
 </script>
 
 <style>

--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import "../../../build/css/_variables.css"
+import "../../../build/css/variables.css"
 import LeoButton from '../../../web-components/button/react'
 import styles from './App.module.css';
 import SvelteReactComponent, { HelloEvent } from './MySvelteComponent/react'

--- a/tests/cssOutput.test.ts
+++ b/tests/cssOutput.test.ts
@@ -3,7 +3,7 @@ const cssOutputData = require('./data/cssOutput.data')
 
 describe("Compare css converterd file to data set", () => {
   // read files
-  let css = fs.readFileSync('./build/css/_variables.css', 'utf8').replace(/^\s+|\s+$/g, '')
+  let css = fs.readFileSync('./build/css/variables.css', 'utf8').replace(/^\s+|\s+$/g, '')
   // remove starting comment
   const lines = css.split('\n')
   // remove comment from start

--- a/tokens/config.js
+++ b/tokens/config.js
@@ -6,11 +6,11 @@ module.exports = {
       buildPath: "build/css/",
       files: [
         {
-          destination: "_variables.css",
+          destination: "variables.css",
           format: "custom/css",
           filter: "filterWeb",
           options: {
-            showFileHeader: false,
+            showFileHeader: true,
           },
         },
       ],

--- a/tokens/legacy-colors.json
+++ b/tokens/legacy-colors.json
@@ -1,0 +1,138 @@
+{
+  "color": {
+    "legacy": {
+      "light-mode": {
+        "background1": {
+          "type": "color",
+          "value": "white"
+        },
+        "background2": {
+          "type": "color",
+          "value": "#F8F9FA"
+        },
+        "text1": {
+          "type": "color",
+          "value": "#212529"
+        },
+        "text2": {
+          "type": "color",
+          "value": "#495057"
+        },
+        "text3": {
+          "type": "color",
+          "value": "#868E96"
+        },
+        "interactive1": {
+          "type": "color",
+          "value": "#EA3A0D"
+        },
+        "interactive2": {
+          "type": "color",
+          "value": "#FB542B"
+        },
+        "interactive3": {
+          "type": "color",
+          "value": "#FF7654"
+        },
+        "interactive4": {
+          "type": "color",
+          "value": "#353DAB"
+        },
+        "interactive5": {
+          "type": "color",
+          "value": "#4C54D2"
+        },
+        "interactive6": {
+          "type": "color",
+          "value": "#737ADE"
+        },
+        "interactive7": {
+          "type": "color",
+          "value": "#212529"
+        },
+        "interactive8": {
+          "type": "color",
+          "value": "#AEB1C2"
+        },
+        "disabled": {
+          "type": "color",
+          "value": "#DADCE8"
+        },
+        "focus-border": {
+          "type": "color",
+          "value": "#A0A5EB"
+        },
+        "divider1": {
+          "type": "color",
+          "value": "#E9E9F4"
+        }
+      },
+      "dark-mode": {
+        "background1": {
+          "type": "color",
+          "value": "#1E2029"
+        },
+        "background2": {
+          "type": "color",
+          "value": "#17171F"
+        },
+        "text1": {
+          "type": "color",
+          "value": "##F0F2FF"
+        },
+        "text2": {
+          "type": "color",
+          "value": "#C2C4CF"
+        },
+        "text3": {
+          "type": "color",
+          "value": "#84889C"
+        },
+        "interactive1": {
+          "type": "color",
+          "value": "#EA3A0D"
+        },
+        "interactive2": {
+          "type": "color",
+          "value": "#FB542B"
+        },
+        "interactive3": {
+          "type": "color",
+          "value": "#FF7654"
+        },
+        "interactive4": {
+          "type": "color",
+          "value": "#353DAB"
+        },
+        "interactive5": {
+          "type": "color",
+          "value": "#4C54D2"
+        },
+        "interactive6": {
+          "type": "color",
+          "value": "#737ADE"
+        },
+        "interactive7": {
+          "type": "color",
+          "value": "#F0F2FF"
+        },
+        "interactive8": {
+          "type": "color",
+          "value": "#5E6175"
+        },
+        "disabled": {
+          "type": "color",
+          "value": "#343A40"
+        },
+        "focus-border": {
+          "type": "color",
+          "value": "#A0A5EB"
+        },
+        "divider1": {
+          "type": "color",
+          "value": "#3B3E4F"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds colors from the pre-leo design system, since apparently they're still being used in new figma designs. Developers have an active need to use these variables, so we'll include them. But, to make sure developers don't use them just because the colors match, or at least know they are not intended to be used forever, we'll use the `"legacy"` prefix.

Output example:

```css
  --color-legacy-text1: rgb(33, 37, 41);
  --color-legacy-light-mode-text1: rgb(33, 37, 41);
  --color-legacy-dark-mode-text1: rgb(0, 0, 0);
@media (prefers-color-scheme: light) {
  --color-legacy-text1: rgb(0, 0, 0);
}
```