### PR TITLE
Auto infer Prop Types for React Components

### DIFF
--- a/web-components/button/react.ts
+++ b/web-components/button/react.ts
@@ -1,17 +1,4 @@
 import SvelteToReact from "../svelte-react";
 import Button from './button.svelte'
-import type * as PropTypes from './props'
 
-// Prop types for a svelte component are not able to be inferred at compile-time,
-// only at dev time in typescript plugins, so we must duplicate it here, manually.
-// TODO: have this type definition be auto-generated in the bundler.
-
-export type Props = {
-  kind: PropTypes.ButtonKind
-  size: PropTypes.ButtonSize,
-  isDisabled: boolean
-  isLoading: boolean
-  onClick: () => unknown
-}
-
-export default SvelteToReact<Props>('leo-button', Button)
+export default SvelteToReact('leo-button', Button)

--- a/web-components/svelte-react.ts
+++ b/web-components/svelte-react.ts
@@ -1,8 +1,14 @@
 import React, { useRef, useEffect } from "react"
 import { SvelteComponent } from "svelte"
+import type {SvelteComponentTyped} from "svelte"
 
 const eventRegex = /on([A-Z]{1,}[a-zA-Z]*)/
 const watchRegex = /watch([A-Z]{1,}[a-zA-Z]*)/
+
+/**
+ * Type Utility for inferring the prop types of a Svelte component.
+ */
+export type SvelteProps<T> = T extends SvelteComponentTyped<infer Props, any, any> ? Props : {};
 
 // TODO(petemill): 
 // When web-components are supported in react (currently only in experimental version), then we can 
@@ -17,7 +23,7 @@ const watchRegex = /watch([A-Z]{1,}[a-zA-Z]*)/
 //       ['leo-button']: CustomElement<Props>
 //     }
 //   }
-// }    
+// }
 
 /**
  * 
@@ -25,9 +31,8 @@ const watchRegex = /watch([A-Z]{1,}[a-zA-Z]*)/
  * @param component The imported svelte component itself. This is not used, but ensures that the component's code has been included in the bundle.
  * @returns A react component
  */
-export default function SvelteWebComponentToReact<T extends Record<string, any>> (tag: string, component: typeof SvelteComponent) {
-  console.log(component)
-  return function ReactSvelteWebComponent (props: React.PropsWithChildren<T>) {
+export default function SvelteWebComponentToReact<Component extends SvelteComponent> (tag: string, component: { new(...args: any[]): Component }) {
+  return function ReactSvelteWebComponent (props: React.PropsWithChildren<SvelteProps<Component>>) {
     const component = useRef<SvelteComponent>()
     
     const setRef = React.useCallback((ref: SvelteComponent) => {
@@ -103,6 +108,6 @@ export default function SvelteWebComponentToReact<T extends Record<string, any>>
       }
     }, [])
 
-    return React.createElement(tag, { ref: setRef, children: props.children })// as unknown as React.ReactElement<T>
+    return React.createElement(tag, { ref: setRef, children: props.children })
   }
 }

--- a/web-components/svelte-react.ts
+++ b/web-components/svelte-react.ts
@@ -1,6 +1,5 @@
 import React, { useRef, useEffect } from "react"
-import { SvelteComponent } from "svelte"
-import type {SvelteComponentTyped} from "svelte"
+import type { SvelteComponent, SvelteComponentTyped } from "svelte"
 
 const eventRegex = /on([A-Z]{1,}[a-zA-Z]*)/
 const watchRegex = /watch([A-Z]{1,}[a-zA-Z]*)/
@@ -9,6 +8,22 @@ const watchRegex = /watch([A-Z]{1,}[a-zA-Z]*)/
  * Type Utility for inferring the prop types of a Svelte component.
  */
 export type SvelteProps<T> = T extends SvelteComponentTyped<infer Props, any, any> ? Props : {};
+
+/**
+ * Type utility for inferring event types of a Svelte component.
+ */
+export type SvelteEvents<T> = T extends SvelteComponentTyped<any, infer Events, any> ? Events : {};
+
+/**
+ * Type utility for getting the React props of a Svelte component. This is all
+ * the Svelte props and the events mapped to the React `onEventName` format.
+ *
+ * For example, the event `click` would be mapped to `onClick`.
+ */
+export type SvelteToReactProps<SvelteComponent> = SvelteProps<SvelteComponent> & {
+  [Prop in keyof SvelteEvents<SvelteComponent> as `on${Capitalize<Prop & string>}`]?: SvelteEvents<SvelteComponent>[Prop];
+}
+
 
 // TODO(petemill): 
 // When web-components are supported in react (currently only in experimental version), then we can 
@@ -31,10 +46,10 @@ export type SvelteProps<T> = T extends SvelteComponentTyped<infer Props, any, an
  * @param component The imported svelte component itself. This is not used, but ensures that the component's code has been included in the bundle.
  * @returns A react component
  */
-export default function SvelteWebComponentToReact<Component extends SvelteComponent> (tag: string, component: { new(...args: any[]): Component }) {
-  return function ReactSvelteWebComponent (props: React.PropsWithChildren<SvelteProps<Component>>) {
+export default function SvelteWebComponentToReact<Component extends SvelteComponent>(tag: string, component: { new(...args: any[]): Component }) {
+  return function ReactSvelteWebComponent(props: React.PropsWithChildren<SvelteToReactProps<Component>>) {
     const component = useRef<SvelteComponent>()
-    
+
     const setRef = React.useCallback((ref: SvelteComponent) => {
       if (!ref) {
         console.error('No component for tag', tag)
@@ -51,7 +66,7 @@ export default function SvelteWebComponentToReact<Component extends SvelteCompon
         return
       }
       component.current = ref
-      
+
       // Events fire callbacks when the event is dispatched
       // from the svelte component.
       // Watchers fire callbacks when the variable (aka property or attribute)


### PR DESCRIPTION
This PR adds the ability to infer the prop types of a Svelte Component, and updates the React Wrapper to automatically use the inferred types.

Picture of working type inference:
![image](https://user-images.githubusercontent.com/7678024/187120383-d2a1076f-8d38-4a0f-afe3-c42900aa104d.png)
