### PR TITLE
Add plugin for extracting component CSS to a separate file

### DIFF
--- a/postcss/fork-css.js
+++ b/postcss/fork-css.js
@@ -1,0 +1,26 @@
+const fs = require('fs')
+const path = require('path')
+
+const getInputPath = (root) => root.source.input.file
+
+module.exports = (options = { outputFolder: 'build', match: /^((?!\.(stories|test)).)*\.svelte/gi, dropExtension: true }) => {
+  const getOutputFile = (inputFile) => {
+    const fileName = path.basename(inputFile, options.dropExtension ? path.extname(inputFile) : undefined);
+    const relativePath = path.relative('.', path.resolve(inputFile, '..'))
+    return path.join(options.outputFolder, relativePath, fileName + '.css');
+  }
+
+  return {
+    postcssPlugin: 'fork-css',
+    OnceExit: (root) => {
+      const inputFile = getInputPath(root);
+      if (!options.match.test(inputFile)) return;
+
+      const outputFile = getOutputFile(inputFile);
+      fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+      fs.writeFileSync(outputFile, root.toString());
+    }
+  }
+}
+
+module.exports.postcss = true;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,13 @@ export default {
     plugins: [
         svelteTypes(),
         svelte({
-            preprocess: sveltePreprocess(),
+            preprocess: sveltePreprocess({
+                postcss: {
+                    plugins: [
+                        require('./postcss/fork-css')
+                    ]
+                }
+            }),
             compilerOptions: {
                 customElement: true
             },


### PR DESCRIPTION
As Leo can be used by many different consumers, it's important that it's as flexible as possible. In this PR, I've added a plugin to extract the CSS from a Svelte component, and dump it in a separate CSS file.

For example the following component at `web-components/jays-cool-button.svelte`:
```svelte
<style lang="sass">
	.foo {
		background: red;
		&:hover {
			background: blue;
		}
	}
</style>
<button class="foo>Click Me</button>
```

Will generate `build/web-components/jays-cool-button.css`
```css
.foo {
	background: red;
}
.foo:hover {
	background: blue;
}
```

The generated CSS can then be in plain HTML:
```html
<head>
	<!-- Include Stylesheets for our CSS variables first -->
	<link rel="stylesheet" href="build/web-components/jays-cool-button.css">
</head>
<body>
	<button class="foo">Click Me</button> <!-- Looks the same as the Svelte Component! -->
</body>
```

This should be a starting point for https://github.com/brave-experiments/leo/issues/4

However, there are a few issues I think need to be resolved before we can land this:
1. Svelte automatically adds a scope to it's styles. I think we should do something similar (maybe with the web-component tag name as the prefix?)
2. I'm not sure how we're going to deal with the web-component/pure styles divide. Some selectors (i.e. :host, :host-context ect) will only work in one or the other, not both.

Suggested possible output:
Possibly, it should generate this instead:
```css
.jays-cool-button .foo {
	background: red;
}

.jays-cool-button .foo:hover {
	background: blue;
}
```