### PR TITLE
Remove redundant declarations

### DIFF
--- a/tokens/transformation/tailwind/formatCssColorVars.js
+++ b/tokens/transformation/tailwind/formatCssColorVars.js
@@ -29,21 +29,15 @@ module.exports = ({ dictionary, options, file }) => {
   // Note: replace strips out 'light-mode' and 'dark-mode' inside media queries
   return (
     fileHeader({ file }) +
-      ':root {\n' +
+      ':root, html[data-theme=light] {\n' +
       formattedVariables({ format: 'tailwind', dictionary: groupedTokens.rest, outputReferences }).replace(/desktop-/gm, "") +
-      '\n}\n\n' +
-      '@media (prefers-color-scheme: light) {\n' +
-      ' :root {\n' +
       formattedVariables({ format: 'tailwind', dictionary: groupedTokens.light, outputReferences }).replace(/light-mode-/gm, "") +
-      '\n }\n}\n\n' +
+      '\n}\n\n' +
       '@media (prefers-color-scheme: dark) {\n' +
       ' :root {\n' +
       formattedVariables({ format: 'tailwind', dictionary: groupedTokens.dark, outputReferences }).replace(/dark-mode-/gm, "") +
       '\n }\n}\n\n' +
-      '[data-theme="light"] {\n' +
-      formattedVariables({ format: 'tailwind', dictionary: groupedTokens.light, outputReferences }).replace(/light-mode-/gm, "") +
-      '\n}\n\n' +
-      '[data-theme="dark"] {\n' +
+      'html[data-theme="dark"] {\n' +
       formattedVariables({ format: 'tailwind', dictionary: groupedTokens.dark, outputReferences }).replace(/dark-mode-/gm, "") +
       '\n}\n'
   )

--- a/tokens/transformation/web/formatCss.js
+++ b/tokens/transformation/web/formatCss.js
@@ -29,20 +29,14 @@ module.exports = ({ dictionary, options, file }) => {
   // Note: replace strips out 'light-mode' and 'dark-mode' inside media queries
   return (
     fileHeader({ file }) +
-      ':root {\n' +
+      ':root, html[data-theme=light] {\n' +
       formattedVariables({ format: 'css', dictionary: groupedTokens.rest, outputReferences }).replace(/desktop-/gm, "") +
-      '\n}\n\n' +
-      '@media (prefers-color-scheme: light) {\n' +
-      ' :root {\n' +
       formattedVariables({ format: 'css', dictionary: groupedTokens.light, outputReferences }).replace(/light-mode-/gm, "") +
-      '\n }\n}\n\n' +
+      '\n}\n\n' +
       '@media (prefers-color-scheme: dark) {\n' +
       ' :root {\n' +
       formattedVariables({ format: 'css', dictionary: groupedTokens.dark, outputReferences }).replace(/dark-mode-/gm, "") +
       '\n }\n}\n\n' +
-      'html[data-theme="light"] {\n' +
-      formattedVariables({ format: 'css', dictionary: groupedTokens.light, outputReferences }).replace(/light-mode-/gm, "") +
-      '\n}\n\n' +
       'html[data-theme="dark"] {\n' +
       formattedVariables({ format: 'css', dictionary: groupedTokens.dark, outputReferences }).replace(/dark-mode-/gm, "") +
       '\n}\n'


### PR DESCRIPTION
Fixes #33

This reduces the generate size of `css/variables.css` by ~12% and of `tailwind/variables.css` by ~15%