### PR TITLE
Add script for generating React bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .DS_Store
 build/
 web-components/**/*.svelte.d.ts
+web-components/**/react.ts

--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
     "typescript": "^4.8.4"
   },
   "scripts": {
-    "install": "npm run transform-tokens",
-    "start": "npm run transform-tokens",
+    "install": "npm run build",
+    "start": "npm run build",
+    "build": "npm run transform-tokens && npm run gen-types && npm run gen-bindings",
     "gen-types": "node ./scripts/gen-svelte-types.js",
+    "gen-bindings": "node ./scripts/gen-react-bindings.js",
     "transform-tokens": "node ./tokens/transformTokens.js",
     "test": "jest tests --coverage=false",
     "transform:android": "node ./examples/android/build.js",

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,0 +1,21 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+async function* walk(dir) {
+    for await (const d of await fs.opendir(dir)) {
+        const entry = path.join(dir, d.name);
+        if (d.isDirectory()) yield* walk(entry);
+        else if (d.isFile()) yield entry;
+    }
+}
+
+module.exports = {
+    getSvelteFiles: async function* (root, includeDts=true) {
+        for await (const file of await walk(root)) {
+            if (!file.includes('.svelte') || file.includes('.stories.svelte') || (!includeDts && file.endsWith('.d.ts')))
+                continue
+
+            yield file
+        }
+    }
+}

--- a/scripts/gen-react-bindings.js
+++ b/scripts/gen-react-bindings.js
@@ -1,0 +1,42 @@
+const fs = require('fs/promises');
+const path = require('path');
+const { getSvelteFiles } = require('./common');
+
+const COMPONENT_PREFIX = 'leo';
+const SVELTE_REACT_WRAPPER_PATH = path.resolve(__dirname, '../web-components/svelte-react');
+const REACT_FILE_NAME = 'react.ts';
+
+const getReactFileContents = (svelteFilePath) => {
+    const fileDir = path.dirname(svelteFilePath);
+    const svelteReactWrapperRelativePath = path.relative(fileDir, SVELTE_REACT_WRAPPER_PATH);
+
+    const fileName = path.basename(svelteFilePath);
+    const extension = path.extname(fileName);
+    const fileNameWithoutExtension = fileName.substring(0, fileName.length - extension.length);
+    const componentName = fileNameWithoutExtension[0].toUpperCase() + fileNameWithoutExtension.substring(1);
+    const fileContents = `
+import SvelteToReact, { ReactProps } from '${svelteReactWrapperRelativePath}';
+import ${componentName} from './${fileName}';
+import type { ${componentName}Events, ${componentName}Props } from './${fileName}';
+
+export default SvelteToReact<ReactProps<${componentName}Props, ${componentName}Events>>('${COMPONENT_PREFIX}-${fileNameWithoutExtension}', ${componentName});
+    `.trim();
+
+    return fileContents
+}
+
+const createReactBinding = async (svelteFilePath) => {
+    const contents = getReactFileContents(svelteFilePath);
+    const reactFilePath = path.join(path.dirname(svelteFilePath), REACT_FILE_NAME);
+
+    await fs.writeFile(reactFilePath, contents);
+}
+
+const createReactBindings = async (rootDir) => {
+    for await (const sveltePath of getSvelteFiles(rootDir, /*includeDts=*/false)) {
+        console.log(`Creating React Binding for ${sveltePath}`);
+        await createReactBinding(sveltePath);
+    }
+}
+
+createReactBindings('./web-components')

--- a/web-components/button/react.ts
+++ b/web-components/button/react.ts
@@ -1,5 +1,0 @@
-import SvelteToReact, { ReactProps } from '../svelte-react';
-import Button from './button.svelte';
-import type { ButtonEvents, ButtonProps } from './button.svelte';
-
-export default SvelteToReact<ReactProps<ButtonProps, ButtonEvents>>('leo-button', Button);

--- a/web-components/button/react.ts
+++ b/web-components/button/react.ts
@@ -1,9 +1,5 @@
-import SvelteToReact, { ReactProps } from "../svelte-react";
-import Button from './button.svelte'
-import type { ButtonEvents, ButtonProps } from './button.svelte'
+import SvelteToReact, { ReactProps } from '../svelte-react';
+import Button from './button.svelte';
+import type { ButtonEvents, ButtonProps } from './button.svelte';
 
-// Prop types for a svelte component are not able to be inferred at compile-time,
-// only at dev time in typescript plugins, so we must duplicate it here, manually.
-// TODO: have this type definition be auto-generated in the bundler.
-
-export default SvelteToReact<ReactProps<ButtonProps, ButtonEvents>>('leo-button', Button)
+export default SvelteToReact<ReactProps<ButtonProps, ButtonEvents>>('leo-button', Button);


### PR DESCRIPTION
This is based on the `genprops` script. In addition, this PR removes the generated files from the repository and regenerates them as part of the `build` script.